### PR TITLE
Extending subscriptions to take a full parameters object instead of just a channel name + Other Tweaks

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  requirePragma: true
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actioncable-nodejs",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "ActionCable NodeJS client Implementation Edit",
   "main": "src/actioncable.js",
   "scripts": {

--- a/src/actioncable.js
+++ b/src/actioncable.js
@@ -94,7 +94,7 @@ class ActionCable {
 
     if(is_heartbeat_flat) {
       console.log('ActionCable -> Heartbeat has gone flat');
-      this.connection.close();
+      this.connection.close(1012); // 1012 - restarting
     }
   }
 

--- a/src/actioncable.js
+++ b/src/actioncable.js
@@ -23,13 +23,21 @@ class ActionCable {
     this.connection_promise = this._connect();
   }
 
-  subscribe(name, callbacks) {
+  subscribe(name_or_options, callbacks) {
+    if (typeof name_or_options === "string") {
+      name_or_options = {
+        channel: name_or_options
+      };
+    }
+
+    let name = name_or_options.channel;
+
     if(this.subscriptions[name]) {
       throw "Already subscribed to this channel!";
       return;
     }
 
-    this.subscriptions[name] = new Subscription(name, this, callbacks);
+    this.subscriptions[name] = new Subscription(name_or_options, this, callbacks);
     return this.subscriptions[name];
   }
 

--- a/src/subscription.js
+++ b/src/subscription.js
@@ -1,15 +1,16 @@
 class Subscription {
-  constructor(name, cable, callbacks) {
-    this.name = name;
+  constructor(options, cable, callbacks) {
+    this.options = options;
+    this.name = options.channel;
     this.callbacks = callbacks;
     this.cable = cable;
 
     this.cable.connection_promise.then((con) => {
-      console.log(`ActionCable - connecting to ${name}`);
+      console.log(`ActionCable - connecting to ${JSON.stringify(options)}`);
 
       con.send(JSON.stringify({
         command: 'subscribe',
-        identifier: JSON.stringify({channel: name})
+        identifier: JSON.stringify(options)
       }));
     });
   }
@@ -51,7 +52,7 @@ class Subscription {
 
   _create_packet(data) {
     let packet = {
-      identifier: JSON.stringify({ channel: this.name }),
+      identifier: JSON.stringify(this.options),
       command: "message",
       data: JSON.stringify(data)
     };


### PR DESCRIPTION
And a few tweaks:

* Extending subscriptions to take a full parameters object instead of just a channel name
* Using code 1012 (meaning 'restarting') when issuing a disconnect due to heartbeat going flat, seemed appropriate, since it probably just means that it needs to reconnect. This allow for better handling of the disconnection code by client apps.

And a very minor ...
* a .prettierrc on defaults just to play nice with that hope you don't mind ;)



I made this a version bump to 1.1.0

(this is a re-open of https://github.com/ZackMattor/actioncable-nodejs/pull/1)