### PR TITLE
allow logger to be Injectable

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  requirePragma: true
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actioncable-nodejs",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "ActionCable NodeJS client Implementation Edit",
   "main": "src/actioncable.js",
   "scripts": {

--- a/src/actioncable.js
+++ b/src/actioncable.js
@@ -15,6 +15,7 @@ class ActionCable {
     this.headers = opts.headers || {};
     this.connection = null;
     this.subscriptions = {};
+    this.logger = opts.logger || console
 
     // heartbeat state
     this.last_heartbeat_timestamp = null;
@@ -37,7 +38,7 @@ class ActionCable {
       return;
     }
 
-    this.subscriptions[name] = new Subscription(name_or_options, this, callbacks);
+    this.subscriptions[name] = new Subscription(name_or_options, this, callbacks, this.logger);
     return this.subscriptions[name];
   }
 
@@ -93,14 +94,14 @@ class ActionCable {
     let is_heartbeat_flat = (this.last_heartbeat_timestamp + 10*1000) < (+ new Date());
 
     if(is_heartbeat_flat) {
-      console.log('ActionCable -> Heartbeat has gone flat');
+      this.logger.log('ActionCable -> Heartbeat has gone flat');
       this.connection.close(1012); // 1012 - restarting
     }
   }
 
   _disconnected(err) {
-    console.log("ActionCable -> socket disconnected");
-    if(this.heartbeat_interval) { clearInterval(this.heartbeat_interval); console.log('ActionCable -> Cleared the heartbeat interval'); }
+    this.logger.log("ActionCable -> socket disconnected");
+    if(this.heartbeat_interval) { clearInterval(this.heartbeat_interval); this.logger.log('ActionCable -> Cleared the heartbeat interval'); }
 
     for(let sub in this.subscriptions) {
       this.subscriptions[sub].callbacks.disconnected(err);

--- a/src/actioncable.js
+++ b/src/actioncable.js
@@ -94,7 +94,7 @@ class ActionCable {
 
     if(is_heartbeat_flat) {
       console.log('ActionCable -> Heartbeat has gone flat');
-      this.connection.close();
+      this.connection.close(1012); // 1012 - restarting
     }
   }
 

--- a/src/actioncable.js
+++ b/src/actioncable.js
@@ -23,13 +23,21 @@ class ActionCable {
     this.connection_promise = this._connect();
   }
 
-  subscribe(name, callbacks) {
+  subscribe(name_or_options, callbacks) {
+    if (typeof name_or_options === "string") {
+      name_or_options = {
+        channel: name_or_options
+      };
+    }
+
+    let name = name_or_options.channel;
+
     if(this.subscriptions[name]) {
       throw "Already subscribed to this channel!";
       return;
     }
 
-    this.subscriptions[name] = new Subscription(name, this, callbacks);
+    this.subscriptions[name] = new Subscription(name_or_options, this, callbacks);
     return this.subscriptions[name];
   }
 

--- a/src/subscription.js
+++ b/src/subscription.js
@@ -1,15 +1,16 @@
 class Subscription {
-  constructor(name, cable, callbacks) {
-    this.name = name;
+  constructor(options, cable, callbacks) {
+    this.options = options;
+    this.name = options.channel;
     this.callbacks = callbacks;
     this.cable = cable;
 
     this.cable.connection_promise.then((con) => {
-      console.log(`ActionCable - connecting to ${name}`);
+      console.log(`ActionCable - connecting to ${JSON.stringify(options)}`);
 
       con.send(JSON.stringify({
         command: 'subscribe',
-        identifier: JSON.stringify({channel: name})
+        identifier: JSON.stringify(options)
       }));
     });
   }
@@ -51,7 +52,7 @@ class Subscription {
 
   _create_packet(data) {
     let packet = {
-      identifier: JSON.stringify({ channel: this.name }),
+      identifier: JSON.stringify(this.options),
       command: "message",
       data: JSON.stringify(data)
     };

--- a/src/subscription.js
+++ b/src/subscription.js
@@ -1,12 +1,13 @@
 class Subscription {
-  constructor(options, cable, callbacks) {
+  constructor(options, cable, callbacks, logger = console) {
     this.options = options;
     this.name = options.channel;
     this.callbacks = callbacks;
     this.cable = cable;
+    this.logger = logger;
 
     this.cable.connection_promise.then((con) => {
-      console.log(`ActionCable - connecting to ${JSON.stringify(options)}`);
+      this.logger.log(`ActionCable - connecting to ${JSON.stringify(options)}`);
 
       con.send(JSON.stringify({
         command: 'subscribe',
@@ -25,7 +26,7 @@ class Subscription {
           this.callbacks.rejected();
           break;
         default:
-          console.log(`Subscription(${this.name}) - Unhandled message type ${type} | ${data}`);
+          this.logger.log(`Subscription(${this.name}) - Unhandled message type ${type} | ${data}`);
           break;
       }
     } else {
@@ -45,7 +46,7 @@ class Subscription {
       if(con.readyState == 1) {
         con.send(this._create_packet(data));
       } else {
-        console.log('connection is not open');
+        this.logger.log('connection is not open');
       }
     });
   }


### PR DESCRIPTION
This depends on #2 being merged first.

This is an incremental change to that. So in reviewing only look at the commit `Making logger injectable`

--

This makes it so that the logger is injectable and not hardcoded to `console`, allowing better control over it. It defaults to console still so this is a very benign change.